### PR TITLE
Alter image to include php modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Alpine v3.12
 FROM docker:20.10.2-git
 
 ENTRYPOINT /bin/sh
@@ -25,9 +26,24 @@ RUN apk add --no-cache \
     php7-xmlwriter==7.3.26-r0 \
     php7-zip==7.3.26-r0 \
     php7-pdo==7.3.26-r0 \
+    php7-mysqli==7.3.26-r0 \
+    php7-pdo_dblib=7.3.26-r0 \
+    php7-pdo_mysql==7.3.26-r0 \
     php7-xml==7.3.26-r0 \
-    php7-session==7.3.26-r0
+    php7-session==7.3.26-r0 \
+    php7-mbstring==7.3.26-r0
 
 RUN apk add --no-cache \
     nodejs==12.20.1-r0 \
     npm==12.20.1-r0
+
+RUN apk add --no-cache \
+    mariadb==10.4.15-r0 \
+    mariadb-client==10.4.15-r0
+
+RUN rm -f /var/cache/apk/*
+
+COPY my.cnf /etc/my.cnf
+RUN mkdir /run/mysqld
+RUN mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+RUN mysqladmin --no-defaults --port=3308 --user=root password 'root'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # Alpine v3.12
 FROM docker:20.10.2-git
 
-ENTRYPOINT /bin/sh
-
 RUN apk add --no-cache \
     py3-pip==20.1.1-r0 \
     bash==5.0.17-r0 \
@@ -25,25 +23,27 @@ RUN apk add --no-cache \
     php7-ctype==7.3.26-r0 \
     php7-xmlwriter==7.3.26-r0 \
     php7-zip==7.3.26-r0 \
+    php7-bz2==7.3.26-r0 \
+    php7-exif==7.3.26-r0 \
     php7-pdo==7.3.26-r0 \
     php7-mysqli==7.3.26-r0 \
     php7-pdo_dblib=7.3.26-r0 \
     php7-pdo_mysql==7.3.26-r0 \
     php7-xml==7.3.26-r0 \
     php7-session==7.3.26-r0 \
-    php7-mbstring==7.3.26-r0
+    php7-mbstring==7.3.26-r0 \
+    php7-iconv==7.3.26-r0\
+    php7-gmp==7.3.26-r0\
+    php7-xmlrpc==7.3.26-r0\
+    php7-soap==7.3.26-r0\
+    php7-xsl==7.3.26-r0\
+    php7-curl==7.3.26-r0\
+    php7-gd==7.3.26-r0
 
 RUN apk add --no-cache \
     nodejs==12.20.1-r0 \
     npm==12.20.1-r0
 
-RUN apk add --no-cache \
-    mariadb==10.4.15-r0 \
-    mariadb-client==10.4.15-r0
-
 RUN rm -f /var/cache/apk/*
 
-COPY my.cnf /etc/my.cnf
-RUN mkdir /run/mysqld
-RUN mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
-RUN mysqladmin --no-defaults --port=3308 --user=root password 'root'
+ENTRYPOINT ["/bin/sh"]

--- a/my.cnf
+++ b/my.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+user = root
+port = 3306
+bind-address = 0.0.0.0

--- a/my.cnf
+++ b/my.cnf
@@ -1,4 +1,0 @@
-[mysqld]
-user = root
-port = 3306
-bind-address = 0.0.0.0


### PR DESCRIPTION
Additional modules needed to support a command line Drupal Build process.

Removes the built in MySQL server process in favor of using an external image defined in the CircleCi config in the project itself.