### PR TITLE
Adding robo to drupalstand-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,9 @@ RUN apk add --no-cache \
 
 RUN rm -f /var/cache/apk/*
 
+## Install Robo.
+RUN curl -L "https://github.com/consolidation/Robo/releases/download/2.2.0/robo.phar" -o /tmp/robo.phar \
+    && chmod +x /tmp/robo.phar \
+    && mv /tmp/robo.phar /usr/local/bin/robo
+
 ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
As discussed in slack, adding here curl command to download and move robo phar to the PATH.
We could tag this as `latest-robo`
```shell
docker build -t mobomo/drupalstand-ci:latest-robo .
```
So we can pull it only if we need robo on our circleci implementations, like
```yaml
jobs:
  test:
    docker:
      - image: mobomo/drupalstand-ci:latest-robo
```

Thanks!
m